### PR TITLE
[TEST] Disable parallel builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Use TLS1.2
 systemProp.com.ibm.jsse2.overrideDefaultTLS=true
 # Use parallel task execution for faster builds
-org.gradle.parallel=true
+org.gradle.parallel=false
 


### PR DESCRIPTION
Parallel builds stopped working in our toolchain build environment and are giving me problems locally so they have to be disabled. 