### PR TITLE
Remove prometheus from startMonitoring.sh

### DIFF
--- a/startMonitoring.sh
+++ b/startMonitoring.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+<<prometheus_comment
 LOCAL_HOST=`ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1'`
 echo "This hostname is: $LOCAL_HOST"
 
@@ -25,6 +25,7 @@ docker run \
   -v $PROM_LOCAL_CONFIG:/etc/prometheus \
   prom/prometheus --config.file=/etc/prometheus/prometheus.yml --web.listen-address=:9088
   
+prometheus_comment
 
 echo "Starting grafana"
 docker stop lb-grafana 2> /dev/null


### PR DESCRIPTION
We need to do a lot of local changes before starting the prometheus container. It's better to not use the script for now